### PR TITLE
Fix DISABLE_TOOLS array parsing error

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -291,7 +291,7 @@ Sample Claude Desktop Config for local dev with full settings
 			"env": {
 				"DIRECTUS_URL": "https://your-directus-instance.com",
 				"DIRECTUS_TOKEN": "your_directus_token",
-				"DISABLE_TOOLS": ["delete-item", "update-field"],
+				"DISABLE_TOOLS": "[\"delete-item\", \"update-field\"]",
 				"MCP_SYSTEM_PROMPT_ENABLED": "true",
 				"MCP_SYSTEM_PROMPT": "You are an assistant specialized in managing content for our marketing website.",
 				"DIRECTUS_PROMPTS_COLLECTION_ENABLED": "true",

--- a/src/config.ts
+++ b/src/config.ts
@@ -16,8 +16,10 @@ const configSchema = z
 			'The password of the user to login with.',
 		),
 		DISABLE_TOOLS: z
-			.array(z.string())
-			.default(['delete-item'])
+			.string()
+			.default('["delete-item"]')
+			.transform((val) => JSON.parse(val))
+			.pipe(z.array(z.string()))
 			.describe("Disable specific tools by name. Defaults to ['delete-item']"),
 		MCP_SYSTEM_PROMPT_ENABLED: z
 			.string()


### PR DESCRIPTION
## Problem

The current implementation expects `DISABLE_TOOLS` to be an array directly in the Zod schema:

```typescript
DISABLE_TOOLS: z
  .array(z.string())
  .default(['delete-item'])
```

However, environment variables are always strings. When users set:
```bash
export DISABLE_TOOLS='["delete-item", "update-field"]'
```

The configuration parsing would fail because the string couldn't be converted to an array.

## Solution

Updated the configuration schema to accept a JSON string and parse it into an array:

```typescript
DISABLE_TOOLS: z
  .string()
  .default('["delete-item"]')
  .transform((val) => JSON.parse(val))
  .pipe(z.array(z.string()))
```

## Changes Made

1. **src/config.ts**: Modified `DISABLE_TOOLS` schema to parse JSON strings
2. **README.md**: Updated example configuration to show proper JSON string format:
   ```diff
   - "DISABLE_TOOLS": ["delete-item", "update-field"],
   + "DISABLE_TOOLS": "[\"delete-item\", \"update-field\"]",
   ```

## Real-world Usage

Users can now properly set this in their environment:

```bash
# Shell
export DISABLE_TOOLS='["delete-item", "update-field", "read-users"]'

# .env file
DISABLE_TOOLS=["delete-item", "update-field"]
```

```json
{
  "mcpServers": {
    "directus": {
      "command": "npx",
      "args": ["@directus/content-mcp@latest"],
      "env": {
        "DIRECTUS_URL": "https://your-directus-instance.com",
        "DIRECTUS_TOKEN": "your_directus_token",
        "DISABLE_TOOLS": "[\"delete-item\", \"update-field\"]"
      }
    }
  }
}
```